### PR TITLE
fix: correct function name mismatch in Python binding

### DIFF
--- a/bindings/python/tree_sitter_tree_sitter_vb_dotnet/binding.c
+++ b/bindings/python/tree_sitter_tree_sitter_vb_dotnet/binding.c
@@ -2,10 +2,10 @@
 
 typedef struct TSLanguage TSLanguage;
 
-TSLanguage *tree_sitter_tree_sitter_vb_dotnet(void);
+TSLanguage *tree_sitter_vb_dotnet(void);
 
 static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
-    return PyCapsule_New(tree_sitter_tree_sitter_vb_dotnet(), "tree_sitter.Language", NULL);
+    return PyCapsule_New(tree_sitter_vb_dotnet(), "tree_sitter.Language", NULL);
 }
 
 static struct PyModuleDef_Slot slots[] = {


### PR DESCRIPTION
## **User description**
- Fix function name from tree_sitter_tree_sitter_vb_dotnet to tree_sitter_vb_dotnet
- Resolves ImportError: symbol not found in flat namespace
- Function name in binding.c now matches the actual function in parser.c


___

## **CodeAnt-AI Description**
**Fix Python import error for VB.NET parser by correcting binding function name**

### What Changed
- The Python binding now exposes the correct VB.NET function name so importing the VB.NET extension no longer fails with a missing-symbol ImportError.
- Importing the VB.NET module now returns the correct language object, allowing Python code to load and use the VB.NET parser.
- Python-based tools that rely on the VB.NET language capsule (for parsing, syntax highlighting, or code analysis) will work again after this change.

### Impact
`✅ Fixes ImportError when importing VB.NET Python binding`
`✅ Restores VB.NET parsing in Python tools (syntax highlighting, analysis)`
`✅ Enables successful use of the VB.NET extension in Python environments`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
